### PR TITLE
Bug fix: Remove enum from dependency list at setup.py.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,6 @@ setup(
     license='Apache 2.0',
     packages=find_packages(),
     install_requires=[
-        'enum',
         'numpy >= 1.11.1',
         'pandas',
         'patsy',


### PR DESCRIPTION
I tried to add this library to below environment.

```
empirical_calibration git/master  
❯ which python 
/Users/yoshitaka-i/.pyenv/shims/python
                                                                                  
empirical_calibration git/master  
❯ pyenv global       
3.7.3

empirical_calibration git/master  
❯ python --version
Python 3.7.3
```

First, I installed this library using this command

```
python setup.py install --user
```
Then, terminal showed below logs

<details>
<summary>error log </summary>

```
Installed /Users/yoshitaka-i/.local/lib/python3.7/site-packages/empirical_calibration-0.1-py3.7.egg
Processing dependencies for empirical-calibration==0.1
Searching for enum
Reading https://pypi.org/simple/enum/
Downloading https://files.pythonhosted.org/packages/02/a0/32e1d5a21b703f600183e205aafc6773577e16429af5ad3c3f9b956b07ca/enum-0.4.7.tar.gz#sha256=8c7cf3587eda51008bcc1eed99ea2c331ccd265c231dbaa95ec5258d3dc03100
Best match: enum 0.4.7
Processing enum-0.4.7.tar.gz
Writing /var/folders/bl/64v2k_090rd0z7x3bthx011r0000gp/T/easy_install-c37ahbsr/enum-0.4.7/setup.cfg
Running enum-0.4.7/setup.py -q bdist_egg --dist-dir /var/folders/bl/64v2k_090rd0z7x3bthx011r0000gp/T/easy_install-c37ahbsr/enum-0.4.7/egg-dist-tmp-svotnntw
Traceback (most recent call last):
  File "/Users/yoshitaka-i/.pyenv/versions/anaconda3-5.3.1/lib/python3.7/site-packages/setuptools/sandbox.py", line 154, in save_modules
    yield saved
  File "/Users/yoshitaka-i/.pyenv/versions/anaconda3-5.3.1/lib/python3.7/site-packages/setuptools/sandbox.py", line 195, in setup_context
    yield
  File "/Users/yoshitaka-i/.pyenv/versions/anaconda3-5.3.1/lib/python3.7/site-packages/setuptools/sandbox.py", line 250, in run_setup
    _execfile(setup_script, ns)
  File "/Users/yoshitaka-i/.pyenv/versions/anaconda3-5.3.1/lib/python3.7/site-packages/setuptools/sandbox.py", line 45, in _execfile
    exec(code, globals, locals)
  File "/var/folders/bl/64v2k_090rd0z7x3bthx011r0000gp/T/easy_install-c37ahbsr/enum-0.4.7/setup.py", line 24, in <module>
    author='Google LLC',
AttributeError: module 'enum' has no attribute '__version__'

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "setup.py", line 37, in <module>
    'typing',
  File "/Users/yoshitaka-i/.pyenv/versions/anaconda3-5.3.1/lib/python3.7/site-packages/setuptools/__init__.py", line 140, in setup
    return distutils.core.setup(**attrs)
  File "/Users/yoshitaka-i/.pyenv/versions/anaconda3-5.3.1/lib/python3.7/distutils/core.py", line 148, in setup
    dist.run_commands()
  File "/Users/yoshitaka-i/.pyenv/versions/anaconda3-5.3.1/lib/python3.7/distutils/dist.py", line 966, in run_commands
    self.run_command(cmd)
  File "/Users/yoshitaka-i/.pyenv/versions/anaconda3-5.3.1/lib/python3.7/distutils/dist.py", line 985, in run_command
    cmd_obj.run()
  File "/Users/yoshitaka-i/.pyenv/versions/anaconda3-5.3.1/lib/python3.7/site-packages/setuptools/command/install.py", line 67, in run
    self.do_egg_install()
  File "/Users/yoshitaka-i/.pyenv/versions/anaconda3-5.3.1/lib/python3.7/site-packages/setuptools/command/install.py", line 117, in do_egg_install
    cmd.run()
  File "/Users/yoshitaka-i/.pyenv/versions/anaconda3-5.3.1/lib/python3.7/site-packages/setuptools/command/easy_install.py", line 415, in run
    self.easy_install(spec, not self.no_deps)
  File "/Users/yoshitaka-i/.pyenv/versions/anaconda3-5.3.1/lib/python3.7/site-packages/setuptools/command/easy_install.py", line 657, in easy_install
    return self.install_item(None, spec, tmpdir, deps, True)
  File "/Users/yoshitaka-i/.pyenv/versions/anaconda3-5.3.1/lib/python3.7/site-packages/setuptools/command/easy_install.py", line 704, in install_item
    self.process_distribution(spec, dist, deps)
  File "/Users/yoshitaka-i/.pyenv/versions/anaconda3-5.3.1/lib/python3.7/site-packages/setuptools/command/easy_install.py", line 749, in process_distribution
    [requirement], self.local_index, self.easy_install
  File "/Users/yoshitaka-i/.pyenv/versions/anaconda3-5.3.1/lib/python3.7/site-packages/pkg_resources/__init__.py", line 777, in resolve
    replace_conflicting=replace_conflicting
  File "/Users/yoshitaka-i/.pyenv/versions/anaconda3-5.3.1/lib/python3.7/site-packages/pkg_resources/__init__.py", line 1060, in best_match
    return self.obtain(req, installer)
  File "/Users/yoshitaka-i/.pyenv/versions/anaconda3-5.3.1/lib/python3.7/site-packages/pkg_resources/__init__.py", line 1072, in obtain
    return installer(requirement)
  File "/Users/yoshitaka-i/.pyenv/versions/anaconda3-5.3.1/lib/python3.7/site-packages/setuptools/command/easy_install.py", line 676, in easy_install
    return self.install_item(spec, dist.location, tmpdir, deps)
  File "/Users/yoshitaka-i/.pyenv/versions/anaconda3-5.3.1/lib/python3.7/site-packages/setuptools/command/easy_install.py", line 702, in install_item
    dists = self.install_eggs(spec, download, tmpdir)
  File "/Users/yoshitaka-i/.pyenv/versions/anaconda3-5.3.1/lib/python3.7/site-packages/setuptools/command/easy_install.py", line 887, in install_eggs
    return self.build_and_install(setup_script, setup_base)
  File "/Users/yoshitaka-i/.pyenv/versions/anaconda3-5.3.1/lib/python3.7/site-packages/setuptools/command/easy_install.py", line 1155, in build_and_install
    self.run_setup(setup_script, setup_base, args)
  File "/Users/yoshitaka-i/.pyenv/versions/anaconda3-5.3.1/lib/python3.7/site-packages/setuptools/command/easy_install.py", line 1141, in run_setup
    run_setup(setup_script, args)
  File "/Users/yoshitaka-i/.pyenv/versions/anaconda3-5.3.1/lib/python3.7/site-packages/setuptools/sandbox.py", line 253, in run_setup
    raise
  File "/Users/yoshitaka-i/.pyenv/versions/anaconda3-5.3.1/lib/python3.7/contextlib.py", line 130, in __exit__
    self.gen.throw(type, value, traceback)
  File "/Users/yoshitaka-i/.pyenv/versions/anaconda3-5.3.1/lib/python3.7/site-packages/setuptools/sandbox.py", line 195, in setup_context
    yield
  File "/Users/yoshitaka-i/.pyenv/versions/anaconda3-5.3.1/lib/python3.7/contextlib.py", line 130, in __exit__
    self.gen.throw(type, value, traceback)
  File "/Users/yoshitaka-i/.pyenv/versions/anaconda3-5.3.1/lib/python3.7/site-packages/setuptools/sandbox.py", line 166, in save_modules
    saved_exc.resume()
  File "/Users/yoshitaka-i/.pyenv/versions/anaconda3-5.3.1/lib/python3.7/site-packages/setuptools/sandbox.py", line 141, in resume
    six.reraise(type, exc, self._tb)
  File "/Users/yoshitaka-i/.pyenv/versions/anaconda3-5.3.1/lib/python3.7/site-packages/setuptools/_vendor/six.py", line 685, in reraise
    raise value.with_traceback(tb)
  File "/Users/yoshitaka-i/.pyenv/versions/anaconda3-5.3.1/lib/python3.7/site-packages/setuptools/sandbox.py", line 154, in save_modules
    yield saved
  File "/Users/yoshitaka-i/.pyenv/versions/anaconda3-5.3.1/lib/python3.7/site-packages/setuptools/sandbox.py", line 195, in setup_context
    yield
  File "/Users/yoshitaka-i/.pyenv/versions/anaconda3-5.3.1/lib/python3.7/site-packages/setuptools/sandbox.py", line 250, in run_setup
    _execfile(setup_script, ns)
  File "/Users/yoshitaka-i/.pyenv/versions/anaconda3-5.3.1/lib/python3.7/site-packages/setuptools/sandbox.py", line 45, in _execfile
    exec(code, globals, locals)
  File "/var/folders/bl/64v2k_090rd0z7x3bthx011r0000gp/T/easy_install-c37ahbsr/enum-0.4.7/setup.py", line 24, in <module>
    author='Google LLC',
AttributeError: module 'enum' has no attribute '__version__'
```

</details>

Therefore, I removed "enum" from [setup.py](https://github.com/google/empirical_calibration/blob/master/setup.py)