### PR TITLE
Fix issue of reference category dropping in weighting algorithm.

### DIFF
--- a/empirical_calibration/core.py
+++ b/empirical_calibration/core.py
@@ -59,6 +59,8 @@ class Objective(enum.Enum):
   # maximizes the effective sample size.
   QUADRATIC = 1
 
+class ConvergenceError(Exception):
+  pass
 
 def calibrate(covariates: np.ndarray,
               target_covariates: np.ndarray,

--- a/empirical_calibration/core.py
+++ b/empirical_calibration/core.py
@@ -59,8 +59,10 @@ class Objective(enum.Enum):
   # maximizes the effective sample size.
   QUADRATIC = 1
 
+  
 class ConvergenceError(Exception):
   pass
+
 
 def calibrate(covariates: np.ndarray,
               target_covariates: np.ndarray,
@@ -68,9 +70,11 @@ def calibrate(covariates: np.ndarray,
               target_weights: np.ndarray = None,
               autoscale: bool = False,
               objective: Objective = Objective.QUADRATIC,
+              min_weight: float = 0.0,
               max_weight: float = 1.0,
               l2_norm: float = 0) -> Tuple[np.ndarray, bool]:
   """Calibrates covariates toward target.
+  
   It solves a constrained convex optimization problem that minimizes the
   variation of weights for units while achieving direct covariate
   balance. The weighted mean of covariates would match the simple mean

--- a/empirical_calibration/core.py
+++ b/empirical_calibration/core.py
@@ -111,7 +111,7 @@ def calibrate(covariates: np.ndarray,
   att = np.mean(treatment_outcome) - np.sum(control_outcome * weights)
   # Estimate ATT for a multivariate outcome.
   att = np.mean(
-      treatment_outcome, axis=0) - np.matmul(control_outcome.T, weights)
+      treatment_outcome, axis=0) - control_outcome.T @ weights
   ```
   Args:
     covariates: covariates to be calibrated. All values must be numeric.
@@ -195,7 +195,7 @@ def calibrate(covariates: np.ndarray,
       weight_link = lambda x: np.clip(x, min_weight, max_weight)
       # Solution of the dual problem without the non-negative weight constraint.
       # Use pseudoinverse in case z is not full rank.
-      beta_init = np.linalg.pinv(np.matmul(z.T, z)) @ np.concatenate(
+      beta_init = np.linalg.pinv(z.T @ z) @ np.concatenate(
           (np.ones(1), np.zeros(num_covariates)))
     else:
       weight_link = lambda x: np.clip(x * baseline_weights + baseline_weights,
@@ -393,7 +393,8 @@ def dmatrix_from_formula(formula: str, df: pd.DataFrame) -> pd.DataFrame:
       "~0+", "").replace("~1+", "").replace("~", "").split("+")
   return pd.concat([
       patsy.highlevel.dmatrix(
-          "~ 0 + " + dimj, df, return_type="dataframe") for dimj in dimensions
+          f"~ 0 + {dimension}", df,
+          return_type="dataframe") for dimension in dimensions
       ], axis=1)
 
 

--- a/empirical_calibration/core_test.py
+++ b/empirical_calibration/core_test.py
@@ -61,7 +61,7 @@ class EmpiricalCalibrationTest(parameterized.TestCase):
         l2_norm,
         np.linalg.norm(
             np.mean(self.target_covariates, axis=0) -
-            np.matmul(self.covariates.T, weights)))
+            self.covariates.T @ weights))
 
   @parameterized.parameters(
       (ec.Objective.ENTROPY, 0.0, 1.0, 0.0),

--- a/empirical_calibration/core_test.py
+++ b/empirical_calibration/core_test.py
@@ -366,4 +366,4 @@ class FromFormulaTest(parameterized.TestCase):
 
 
 if __name__ == "__main__":
-  googletest.main()
+  unittest.main()

--- a/empirical_calibration/core_test.py
+++ b/empirical_calibration/core_test.py
@@ -29,10 +29,11 @@ from absl.testing import parameterized
 _SIZE = 2000
 
 
-def _mock_calibrate(covariates, target_covariates, target_weights, autoscale,
+def _mock_calibrate(covariates, target_covariates, baseline_weights,
+                    target_weights, autoscale,
                     objective, min_weight, max_weight, l2_norm):
   """Mocks the `calibrate` to return success only when `l2_norm` is large."""
-  del target_covariates, covariates, target_weights,
+  del target_covariates, covariates, target_weights, baseline_weights
   del autoscale, objective, min_weight, max_weight
   if l2_norm < _mock_calibrate.min_feasible_l2_norm:
     return None, False


### PR DESCRIPTION
Includes the following fixes:
1) Workaround to avoid patsy's default behavior of dropping a “reference category” from each categorical variable. This fix is relevant when both a) from_formula() is used, and b) maybe_exact_calibrate() does not find a solution with l2_norm=0. This fix ensures the errors of all categories are included in the calculation of l2_norm.
2) Allow a positive lower bound on the weights, min_weight, as a constraint in the optimization (in addition to the upper bound max_weight).
3) Raise an error if the bracket() function within maybe_exact_calibrate() fails to converge for all l2_norm bounds that are tried.

More details on Fix 1:

In the existing package, when weighting based on categorical variables, one category of each categorical weighting variable is always chosen as a reference category. These reference categories are not included in the calculation of the error, l2_norm. Basically, l2_norm is the sum of the squares of the errors for each category, with terms of the form ((sum of the weights in the category) - (target for the category))^2, and the existing package does not include the errors of the reference categories in this sum.

Hence, the errors of the reference categories are not controlled, and can be quite high for a given set of weights calculated using the existing package. Another consequence of this is that the weights can change based on how the categories of each categorical variable are named, since this can change the reference categories. To address these issues, the present fix ensures that all categories' errors are included in the calculation of l2_norm.